### PR TITLE
HDFS-13514. Avoid edge case where BUFFER_SIZE is 0

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/BenchmarkThroughput.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/BenchmarkThroughput.java
@@ -84,9 +84,9 @@ public class BenchmarkThroughput extends Configured implements Tool {
     InputStream in = new FileInputStream(new File(path.toString()));
     byte[] data = new byte[BUFFER_SIZE];
     long size = 0;
-    while (size >= 0) {
+    do {
       size = in.read(data);
-    }
+    } while (size > 0);
     in.close();
     printMeasurements();
   }


### PR DESCRIPTION
As reported in HDFS-13514, there is a potential bug in the following code block:
```
byte[] data = new byte[BUFFER_SIZE];
long size = 0;
while (size >= 0) {
  size = in.read(data);
}
```
where BUFFER_SIZE is 0
I believe switching to a simple do/while can fix this.