### PR TITLE
HDFS-13513. Avoid edge case where BUFFER_SIZE is 0

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/BenchmarkThroughput.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/BenchmarkThroughput.java
@@ -134,9 +134,9 @@ public class BenchmarkThroughput extends Configured implements Tool {
     InputStream in = fs.open(f);
     byte[] data = new byte[BUFFER_SIZE];
     long val = 0;
-    while (val >= 0) {
+    do {
       val = in.read(data);
-    }
+    } while (val > 0);
     in.close();
     printMeasurements();
   }


### PR DESCRIPTION
As reported in HDFS-13513, there is a potential bug in the following code block:

byte[] data = new byte[BUFFER_SIZE];
long val= 0;
while (val >= 0) {
  val = in.read(data);
}
where BUFFER_SIZE is 0
I believe switching to a simple do/while can fix this.